### PR TITLE
Fix crash on dedi

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ yarn_mappings       = 1.16.3+build.27
 loader_version      = 0.10.0+build.208
 
 #Mod properties
-mod_version         = 0.1.0
+mod_version         = 0.1.1
 maven_group         = me.geek.tom.fallfest
 archives_base_name  = ttg_fallfest
 

--- a/src/main/java/me/geek/tom/fallfest/FallFestClient.java
+++ b/src/main/java/me/geek/tom/fallfest/FallFestClient.java
@@ -2,23 +2,34 @@ package me.geek.tom.fallfest;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
+import net.fabricmc.fabric.api.client.particle.v1.ParticleFactoryRegistry;
 import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
+import net.fabricmc.fabric.api.particle.v1.FabricParticleTypes;
+import net.minecraft.client.particle.FlameParticle;
 import net.minecraft.client.render.RenderLayer;
+import net.minecraft.particle.DefaultParticleType;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 
 
 public class FallFestClient implements ClientModInitializer {
+
+    public static final DefaultParticleType EERIE_FLAME_PARTICLE = Registration.modRegister(Registry.PARTICLE_TYPE, FabricParticleTypes.simple(), "eerie_flame");
+
     @Override
     public void onInitializeClient() {
         FallFest.LOGGER.info("Initialise client!");
         BlockRenderLayerMap.INSTANCE.putBlock(Registration.EERIE_TORCH_BLOCK, RenderLayer.getCutout());
         BlockRenderLayerMap.INSTANCE.putBlock(Registration.EERIE_WALL_TORCH_BLOCK, RenderLayer.getCutout());
         BlockRenderLayerMap.INSTANCE.putBlock(Registration.CURSED_SPAWNER_BLOCK, RenderLayer.getCutout());
+
+        // Register particles
+        ParticleFactoryRegistry.getInstance().register(EERIE_FLAME_PARTICLE, FlameParticle.Factory::new);
 
         ClientSidePacketRegistry.INSTANCE.register(FallFest.SPAWNER_EFFECT_PACKET_ID, (ctx, data) -> {
             BlockPos pos = data.readBlockPos();
@@ -56,7 +67,7 @@ public class FallFestClient implements ClientModInitializer {
                         world.playSound(pos.getX(), pos.getY(), pos.getZ(), SoundEvents.UI_TOAST_CHALLENGE_COMPLETE,
                                 SoundCategory.MASTER, 1.0f, 1.0f, false);
                         for (int i = 0; i < 250; i++) {
-                            world.addParticle(Registration.EERIE_FLAME_PARTICLE, false,
+                            world.addParticle(EERIE_FLAME_PARTICLE, false,
                                     pos.getX() + 0.5,
                                     pos.getY() + 1.5,
                                     pos.getZ() + 0.5,

--- a/src/main/java/me/geek/tom/fallfest/Registration.java
+++ b/src/main/java/me/geek/tom/fallfest/Registration.java
@@ -24,16 +24,13 @@ public class Registration {
     // =======================================================
     //                      Eerie torch
 
-    public static final DefaultParticleType EERIE_FLAME_PARTICLE = modRegister(Registry.PARTICLE_TYPE,
-            FabricParticleTypes.simple(), "eerie_flame");
-
     public static final TorchBlock EERIE_TORCH_BLOCK = modRegister(Registry.BLOCK,
             new EerieTorch.EerieTorchBlock(
                     FabricBlockSettings.of(Material.SUPPORTED)
                             .noCollision()
                             .breakInstantly()
                             .luminance(Registration::torchBrightness)
-                            .sounds(BlockSoundGroup.WOOD), EERIE_FLAME_PARTICLE),
+                            .sounds(BlockSoundGroup.WOOD), FallFestClient.EERIE_FLAME_PARTICLE),
             "eerie_torch");
     public static final TorchBlock EERIE_WALL_TORCH_BLOCK = modRegister(Registry.BLOCK,
             new EerieTorch.EerieWallTorchBlock(
@@ -42,7 +39,7 @@ public class Registration {
                             .breakInstantly()
                             .luminance(Registration::torchBrightness)
                             .sounds(BlockSoundGroup.WOOD)
-                            .dropsLike(EERIE_TORCH_BLOCK), EERIE_FLAME_PARTICLE),
+                            .dropsLike(EERIE_TORCH_BLOCK), FallFestClient.EERIE_FLAME_PARTICLE),
             "eerie_wall_torch");
     public static final WallStandingBlockItem EERIE_TORCH_ITEM = modRegister(Registry.ITEM,
             new WallStandingBlockItem(EERIE_TORCH_BLOCK, EERIE_WALL_TORCH_BLOCK, new FabricItemSettings().group(ItemGroup.DECORATIONS)),
@@ -64,10 +61,9 @@ public class Registration {
 
     public static void init() {
         // Trigger classload - registers stuff.
-        ParticleFactoryRegistry.getInstance().register(EERIE_FLAME_PARTICLE, FlameParticle.Factory::new);
     }
 
-    private static <T> T modRegister(Registry<? super T> reg, T object, String name) {
+    public static <T> T modRegister(Registry<? super T> reg, T object, String name) {
         return Registry.register(reg, FallFest.modIdentifier(name), object);
     }
 


### PR DESCRIPTION
Quick PR that moves particles and particle registration to your client init class to avoid crashing on dedicated servers.

Version bump to 0.1.1. Let me know if you want me to change anything. Thanks!